### PR TITLE
f5_pool does not accept members attribute of 'none' or ['none']

### DIFF
--- a/lib/puppet/type/f5_pool.rb
+++ b/lib/puppet/type/f5_pool.rb
@@ -244,7 +244,9 @@ Puppet::Type.newtype(:f5_pool) do
       end
     end
     munge do |value|
-      value['port'] = value['port'].to_s
+      if value.is_a?(Hash)
+        value['port'] = value['port'].to_s
+      end
       value
     end
   end


### PR DESCRIPTION
Re: Puppet ticket MODULES-4814

Prior to this commit, the f5_pool type failed to test whether the members
property value was a hash, such as when it is 'none', before accessing it
its value during newproperty members munge.

With this commit, it checks the type to avoid a type error.