### PR TITLE
config_save task

### DIFF
--- a/tasks/config_save.json
+++ b/tasks/config_save.json
@@ -1,0 +1,11 @@
+{
+  "description": "Save the running configuration of an F5 device",
+  "input_method": "stdin",
+  "supports_noop": true,
+  "parameters": {
+    "target": {
+      "description": "The name of a device in device.conf on the (proxy) Puppet agent",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/config_save.rb
+++ b/tasks/config_save.rb
@@ -1,0 +1,135 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'json'
+require 'puppet'
+require 'puppet/util/network_device/config'
+require '../lib/puppet/provider/f5.rb'
+
+# Read input
+
+args = JSON.parse(STDIN.read)
+noop = args['_noop'] ? '--noop' : ''
+target = args['target'] ? args['target'] : ''
+
+# Initialize variables
+
+save_result = ''
+result = {}
+exitcode = 0
+
+# Validate the 'target' parameter
+
+if target.empty?
+  result[:_error] = {
+    msg: 'param error: no target specified',
+    kind: 'f5devcentral/f5-puppet',
+    details: {
+      params: {
+        noop: noop,
+        target: target
+      }
+    }
+  }
+  exitcode = 1
+  puts result.to_json
+  exit exitcode
+end
+
+# Read deviceconfig to identify the device and its url
+
+Puppet.initialize_settings
+devices = Puppet::Util::NetworkDevice::Config.devices.dup
+devices.select! { |key, _value| key == target }
+if devices.empty?
+  result[:_error] = {
+    msg: "config error: unable to find device in #{Puppet[:deviceconfig]}",
+    kind: 'f5devcentral/f5-puppet',
+    details: {
+      params: {
+        noop: noop,
+        target: target
+      }
+    }
+  }
+  exitcode = 1
+  puts result.to_json
+  exit exitcode
+end
+
+device_url = URI.parse(devices[target].url).to_s
+
+# Validate device url
+
+if device_url.empty?
+  result[:_error] = {
+    msg: "config error: unable to find url in #{Puppet[:deviceconfig]}",
+    kind: 'f5devcentral/f5-puppet',
+    details: {
+      params: {
+        noop: noop,
+        target: target
+      }
+    }
+  }
+  exitcode = 1
+  puts result.to_json
+  exit exitcode
+end
+
+# Honor the 'noop' parameter
+
+if noop == 'true'
+  result['noop'] = {
+    msg: 'skipping rest api call of the save command',
+    kind: 'f5devcentral/f5-puppet',
+    details: {
+      params: {
+        noop: noop,
+        target: target
+      }
+    }
+  }
+  puts result.to_json
+  exit exitcode
+end
+
+# Execute the task
+
+begin
+  f5 = Puppet::Util::NetworkDevice::Transport::F5.new(device_url)
+  save_result = f5.post('/mgmt/tm/sys/config', { 'command' => 'save' }.to_json)
+  unless save_result.status == 200
+    error = "http status code: #{save_result.status}"
+    # " http response: #{save_result.body}"
+    exitcode = 1
+  end
+rescue => e
+  error = e.message
+  exitcode = 1
+end
+
+# Compose the result
+
+if exitcode.zero?
+  result[target] = {
+    status: 'success',
+    result: 'running configuration saved to startup configuration'
+  }
+else
+  result[:_error] = {
+    msg: 'rest api error',
+    kind: 'f5devcentral/f5-puppet',
+    details: {
+      params: {
+        noop: noop,
+        target: target
+      },
+      error: error
+    }
+  }
+end
+
+# Return the result
+
+puts result.to_json
+exit exitcode


### PR DESCRIPTION
On versions of Puppet Enterprise (2017.3.x or higher) that support tasks, 
this commit provides a puppet task which can be used to orchestrate a 
config save of an F5 device via a (proxy) Puppet agent.

```
puppet task run f5::config_save --nodes proxy.example.com target=bigip.example.com
```

This is a functional and tested task, but could simply serve as an example.