### PR TITLE
Set more core facts

### DIFF
--- a/lib/puppet/util/network_device/f5/facts.rb
+++ b/lib/puppet/util/network_device/f5/facts.rb
@@ -41,9 +41,15 @@ class Puppet::Util::NetworkDevice::F5::Facts
     end
 
     # Map F5 names to expected standard names.
-    facts[:fqdn]            = facts[:hostname]
-    facts[:macaddress]      = facts[:baseMac]
+    facts[:fqdn]                   = facts[:hostname]
+    facts[:macaddress]             = facts[:baseMac]
+    facts[:operatingsystemrelease] = facts[:version]
+    facts[:ipaddress]              = facts[:managementIp]
+    facts[:productname]            = facts[:marketingName]
 
+    facts[:interfaces] = 'mgmt'
+    facts[:ipaddress_mgmt]  = facts[:ipaddress]
+    facts[:macaddress_mgmt] = facts[:macaddress]
     return facts
   end
 end


### PR DESCRIPTION
By setting some extra 'core' facts, I was able to get Foreman to work.

In particular, without the 'operatingsystemrelease' fact, Foreman was
unable to create an F5 operating system and would throw an error during
fact upload.

Foreman also makes use of `productname` and `interfaces`.

See
https://github.com/theforeman/foreman/blob/8195b2557b5db1b9a6489e6da6b394e0cec56630/app/services/puppet_fact_parser.rb