### PR TITLE
Use relative paths for require

### DIFF
--- a/lib/puppet/provider/f5_addtotrust/rest.rb
+++ b/lib/puppet/provider/f5_addtotrust/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_addtotrust).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_configsync/rest.rb
+++ b/lib/puppet/provider/f5_configsync/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_configsync).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_device/rest.rb
+++ b/lib/puppet/provider/f5_device/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_device).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_devicegroup/rest.rb
+++ b/lib/puppet/provider/f5_devicegroup/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_devicegroup).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_dns/rest.rb
+++ b/lib/puppet/provider/f5_dns/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_dns).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_globalsetting/rest.rb
+++ b/lib/puppet/provider/f5_globalsetting/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_globalsetting).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_license/rest.rb
+++ b/lib/puppet/provider/f5_license/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_license).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_ntp/rest.rb
+++ b/lib/puppet/provider/f5_ntp/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_ntp).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_root/rest.rb
+++ b/lib/puppet/provider/f5_root/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_root).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_route/rest.rb
+++ b/lib/puppet/provider/f5_route/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_route).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_selfdevice/rest.rb
+++ b/lib/puppet/provider/f5_selfdevice/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_selfdevice).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_user/rest.rb
+++ b/lib/puppet/provider/f5_user/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_user).provide(:rest, parent: Puppet::Provider::F5) do


### PR DESCRIPTION
Apply the same fix as https://github.com/f5devcentral/f5-puppet/commit/8c458702d03ba9c994c66a8464e8b7c3299f80b1 to the new types.

The providers work fine with puppet resource, but with puppetserver 2.8 I was getting...
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Sta
tement, Could not autoload puppet/type/f5_ntp: Could not autoload puppet/provider/f5_ntp/rest: no such file to load -- puppet/provider/f5 at /etc/puppetlabs/code/environments/f5_test/roles_and_profiles/profi
le/manifests/f5.pp:6:3 on node f5-test-web-lb.example.com
```