### PR TITLE
Use relative paths for require

### DIFF
--- a/lib/puppet/provider/f5_addtotrust/rest.rb
+++ b/lib/puppet/provider/f5_addtotrust/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_addtotrust).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_configsync/rest.rb
+++ b/lib/puppet/provider/f5_configsync/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_configsync).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_datagroupexternal/rest.rb
+++ b/lib/puppet/provider/f5_datagroupexternal/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_datagroupexternal).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_device/rest.rb
+++ b/lib/puppet/provider/f5_device/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_device).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_devicegroup/rest.rb
+++ b/lib/puppet/provider/f5_devicegroup/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_devicegroup).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_dns/rest.rb
+++ b/lib/puppet/provider/f5_dns/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_dns).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_globalsetting/rest.rb
+++ b/lib/puppet/provider/f5_globalsetting/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_globalsetting).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_license/rest.rb
+++ b/lib/puppet/provider/f5_license/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_license).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_ntp/rest.rb
+++ b/lib/puppet/provider/f5_ntp/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_ntp).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_root/rest.rb
+++ b/lib/puppet/provider/f5_root/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_root).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_route/rest.rb
+++ b/lib/puppet/provider/f5_route/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_route).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_selfdevice/rest.rb
+++ b/lib/puppet/provider/f5_selfdevice/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_selfdevice).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_snat/rest.rb
+++ b/lib/puppet/provider/f5_snat/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_snat).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_snatpool/rest.rb
+++ b/lib/puppet/provider/f5_snatpool/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_snatpool).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_sslcertificate/rest.rb
+++ b/lib/puppet/provider/f5_sslcertificate/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_sslcertificate).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_sslkey/rest.rb
+++ b/lib/puppet/provider/f5_sslkey/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_sslkey).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_user/rest.rb
+++ b/lib/puppet/provider/f5_user/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_user).provide(:rest, parent: Puppet::Provider::F5) do


### PR DESCRIPTION
Supersedes https://github.com/f5devcentral/f5-puppet/pull/11

This PR is rebased against the development branch and also includes changes to the new types on that branch.