### PR TITLE
Changed the f5_command module implementation, to execute native tmsh or bash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1847,7 +1847,7 @@ Specifies the 'to-group' device group to run a config-sync
 
 ### f5_command
 
-Sends an arbitrary command to an BIG-IP node. TMSH command has no `ensure => absent` functionality.
+Sends an arbitrary command to an BIG-IP node. TMSH command has no `ensure => absent` functionality.It provides a way to execute native tmsh or bash commands ( using the REST API (/mgmt/tm/util/bash)
 
 #### Parameters
 
@@ -1871,11 +1871,7 @@ Specifies the command to send to the remote BIG-IP device over the configured pr
 
 ~~~puppet
   f5_command { '/Common/tmsh':
-    tmsh => {
-      command =>"mv",
-      name    =>"bigip1",
-      target  =>"bigip-a.f5.local",
-    }
+    tmsh  => "tmsh create ltm node 2.2.2.2",
   }
 ~~~
 

--- a/lib/puppet/provider/f5_command/rest.rb
+++ b/lib/puppet/provider/f5_command/rest.rb
@@ -19,13 +19,9 @@ Puppet::Type.type(:f5_command).provide(:rest, parent: Puppet::Provider::F5) do
     map = {
     }
 
-    message = strip_nil_values(message)
-    message = convert_underscores(message)
-    message = rename_keys(map, message)
-    message = create_message(basename, message)
-    message = string_to_integer(message)
-
-   message = message[:tmsh]
+   command = message[:tmsh]
+   command ="-c " + "\"" + command +"\""
+   message = {"command"=> "run", "utilCmdArgs"=> command }
 
   message.to_json
   end
@@ -35,7 +31,7 @@ Puppet::Type.type(:f5_command).provide(:rest, parent: Puppet::Provider::F5) do
   end
 
   def create
-    result = Puppet::Provider::F5.post("/mgmt/tm/cm/device", message(resource))
+    result = Puppet::Provider::F5.post("/mgmt/tm/util/bash", message(resource))
     # We clear the hash here to stop flush from triggering.
     @property_hash.clear
 

--- a/lib/puppet/type/f5_command.rb
+++ b/lib/puppet/type/f5_command.rb
@@ -18,7 +18,7 @@ Puppet::Type.newtype(:f5_command) do
 
   newproperty(:description, :parent => Puppet::Property::F5Description)
 
-  newparam(:tmsh) do
+  newproperty(:tmsh) do
     desc "tmsh command line"
   end
 


### PR DESCRIPTION
For the original design, to execute a TMSH command, you have to:
1) specify an absolute URI, such as /mgmt/tm/cm/device
2) along with JSON body
{
"command":"mv",
"name":"bigip1",
"target":"selfdevice2",
}
both of above are different for different TMSH commands.

The new way of implementation is to simplify, by providing a way to execute native tmsh or bash commands using the REST API (/mgmt/tm/util/bash). All the user has to provide is the exact TMSH or bash command.

Here is an example: (tmsh to create a node)
  f5_command { '/Common/tmsh':
    tmsh  => "tmsh create ltm node 2.2.2.2",
  }

It's tested, with document updated.