### PR TITLE
Allow route domain `%0` to be on end of node names

### DIFF
--- a/lib/puppet/parameter/f5_namewithroutedomain.rb
+++ b/lib/puppet/parameter/f5_namewithroutedomain.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter'
+require File.join(File.dirname(__FILE__), 'f5_name.rb')
 
 class Puppet::Parameter::F5NameWithRouteDomain < Puppet::Parameter::F5Name
   validate do |value|

--- a/lib/puppet/parameter/f5_namewithroutedomain.rb
+++ b/lib/puppet/parameter/f5_namewithroutedomain.rb
@@ -1,0 +1,8 @@
+require 'puppet/parameter'
+
+class Puppet::Parameter::F5NameWithRouteDomain < Puppet::Parameter::F5Name
+  validate do |value|
+    fail ArgumentError, "#{name} must be a String" unless value.is_a?(String)
+    fail ArgumentError, "#{name} must match the pattern /Partition/name" unless value.match(%r{/[\w\.-]+/[\w\.-]+(\%\d+)?$})
+  end
+end

--- a/lib/puppet/type/f5_node.rb
+++ b/lib/puppet/type/f5_node.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:f5_node) do
   apply_to_device
   ensurable
 
-  newparam(:name, :parent => Puppet::Parameter::F5Name, :namevar => true)
+  newparam(:name, :parent => Puppet::Parameter::F5NameWithRouteDomain, :namevar => true)
   newproperty(:address, :parent => Puppet::Property::F5Address)
   newproperty(:state, :parent => Puppet::Property::F5State)
   newproperty(:description, :parent => Puppet::Property::F5Description)

--- a/lib/puppet/type/f5_node.rb
+++ b/lib/puppet/type/f5_node.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__),'..','..','puppet/parameter/f5_name.rb'))
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','puppet/parameter/f5_namewithroutedomain.rb'))
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','puppet/property/f5_address.rb'))
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','puppet/property/f5_availability_requirement.rb'))
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','puppet/property/f5_connection_limit.rb'))

--- a/spec/acceptance/f5_node/rest_spec.rb
+++ b/spec/acceptance/f5_node/rest_spec.rb
@@ -12,6 +12,17 @@ describe 'f5_node' do
     run_device(:allow_changes => true)
     run_device(:allow_changes => false)
   end
+  it 'creates a node with a route domain' do
+    pp=<<-EOS
+    f5_node { '/Common/10.10.10.10%0':
+      ensure  => present,
+      address => '10.10.10.10',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(:allow_changes => true)
+    run_device(:allow_changes => false)
+  end
   it 'updates a basic monitor called my_node' do
     pp=<<-EOS
     f5_node { '/Common/my_node':


### PR DESCRIPTION
Addresses issue #29 
Doesn't address the over-prefetching of nodes.