### PR TITLE
remove space from ftp on ftp_profile

### DIFF
--- a/lib/puppet/provider/f5_virtualserver/standard.rb
+++ b/lib/puppet/provider/f5_virtualserver/standard.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:f5_virtualserver).provide(:standard, parent: Puppet::Provider
         ssl_profile_client:                     ssl_profile_client.empty? ? ["none"] : ssl_profile_client,
         ssl_profile_server:                     ssl_profile_server.empty? ? ["none"] : ssl_profile_server,
         http_profile:                           ((applied_profiles["http"            ]||[]).first || {})["fullPath"] || "none",
-        ftp_profile:                            ((applied_profiles["ftp "            ]||[]).first || {})["fullPath"] || "none",
+        ftp_profile:                            ((applied_profiles["ftp"             ]||[]).first || {})["fullPath"] || "none",
         rtsp_profile:                           ((applied_profiles["rtsp"            ]||[]).first || {})["fullPath"] || "none",
         socks_profile:                          ((applied_profiles["socks"           ]||[]).first || {})["fullPath"] || "none",
         xml_profile:                            ((applied_profiles["xml"             ]||[]).first || {})["fullPath"] || "none",


### PR DESCRIPTION
The **ftp_profile** is always set to **'none'**

There is an extra space on ftp_profile preventing it to be get/set properly: https://github.com/f5devcentral/f5-puppet/blob/db4ddfedf9cb0775ab5da995c1b1e5f7790526e9/lib/puppet/provider/f5_virtualserver/standard.rb#L160