### PR TITLE
sort records in datagroup instances

### DIFF
--- a/lib/puppet/provider/f5_datagroup/rest.rb
+++ b/lib/puppet/provider/f5_datagroup/rest.rb
@@ -11,6 +11,13 @@ Puppet::Type.type(:f5_datagroup).provide(:rest, parent: Puppet::Provider::F5) do
     dgroups.each do |dgroup|
       full_path_uri = dgroup['fullPath'].gsub('/','~')
 
+      unless dgroup['records'].nil?
+        records = dgroup['records'].sort {|a, b| a['name'] <=> b['name']}
+      else
+        records = nil
+      end
+
+
     instances << new(
       ensure:                   :present,
       name:                     dgroup['fullPath'],

--- a/lib/puppet/provider/f5_datagroup/rest.rb
+++ b/lib/puppet/provider/f5_datagroup/rest.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:f5_datagroup).provide(:rest, parent: Puppet::Provider::F5) do
       name:                     dgroup['fullPath'],
       description:              dgroup['description'],
       type:                     dgroup['type'],
-      records:                  dgroup['records'],
+      records:                  records,
     )
     end
 


### PR DESCRIPTION
when running puppet device and configuring datagroups they are always logged as being changed because they are sorted differently by f5 than a sorted hash looks in ruby. 