### PR TITLE
f5_virtualserver provider fails when destination contains an ipv6 address

### DIFF
--- a/lib/puppet/provider/f5_virtualserver.rb
+++ b/lib/puppet/provider/f5_virtualserver.rb
@@ -222,4 +222,26 @@ class Puppet::Provider::F5Virtualserver < Puppet::Provider::F5
 
     message.to_json
   end
+
+  # destination may contain an IPV4 or IPV6 address
+
+  def self.address_and_port(destination)
+    if destination.split('/').count < 2
+      raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
+    end
+    address_and_port = destination.split('/')[-1]
+    if (matched = address_and_port.match(/(?<address>.*?)\:(?<port>\d+)$/))
+      # IPV4
+      address = matched[:address]
+      port    = matched[:port]
+    elsif (matched = address_and_port.match(/(?<address>.*?)\.(?<port>\d+)$/))
+      # IPV6
+      address = matched[:address]
+      port    = matched[:port]
+    else
+      raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
+    end
+    port = '*' if port.to_i.zero?
+    [address, port]
+  end
 end

--- a/lib/puppet/provider/f5_virtualserver/forwarding_ip.rb
+++ b/lib/puppet/provider/f5_virtualserver/forwarding_ip.rb
@@ -25,9 +25,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:forwarding_ip, parent: Puppet::Pro
     clear_profile_type_cache
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/forwarding_layer_2.rb
+++ b/lib/puppet/provider/f5_virtualserver/forwarding_layer_2.rb
@@ -28,9 +28,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:forwarding_layer_2, parent: Puppet
     clear_profile_type_cache
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/performance_http.rb
+++ b/lib/puppet/provider/f5_virtualserver/performance_http.rb
@@ -31,9 +31,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:performance_http, parent: Puppet::
     end
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/performance_l4.rb
+++ b/lib/puppet/provider/f5_virtualserver/performance_l4.rb
@@ -31,9 +31,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:performance_l4, parent: Puppet::Pr
     end
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/reject.rb
+++ b/lib/puppet/provider/f5_virtualserver/reject.rb
@@ -18,9 +18,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:reject, parent: Puppet::Provider::
     clear_profile_type_cache
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/standard.rb
+++ b/lib/puppet/provider/f5_virtualserver/standard.rb
@@ -41,8 +41,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:standard, parent: Puppet::Provider
     end
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]

--- a/lib/puppet/provider/f5_virtualserver/stateless.rb
+++ b/lib/puppet/provider/f5_virtualserver/stateless.rb
@@ -20,9 +20,8 @@ Puppet::Type.type(:f5_virtualserver).provide(:stateless, parent: Puppet::Provide
     clear_profile_type_cache
 
     virtualservers.each do |vserver|
-      destination_address = vserver['destination'].match(%r{/([^/]+):})[1]
-      destination_port    = vserver['destination'].match(%r{:(\d+)$})[1]
-      destination_port    = "*" if destination_port == 0
+      destination_address, destination_port = address_and_port(vserver['destination'])
+
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }
       elsif vserver["vlansDisabled"] and vserver["vlans"]


### PR DESCRIPTION
With this commit, f5_virtualserver handles ipv6 addresses in destination.

For example: "/Common/2001:0db8:85a3:0000:0000:8a2e:0370:7334.80"