### PR TITLE
sync-failover device group support

### DIFF
--- a/lib/puppet/util/network_device/f5/facts.rb
+++ b/lib/puppet/util/network_device/f5/facts.rb
@@ -17,7 +17,11 @@ class Puppet::Util::NetworkDevice::F5::Facts
     }
 
     if response = @transport.call('/mgmt/tm/cm/device') and items = response['items']
-      result = items.first
+      if items.first['selfDevice'] == 'true'
+        result = items[0]
+      else
+        result = items[1] 
+      end
     else
       Puppet.warning("Did not receive device details. iControl REST requires Administrator level access.")
       return facts
@@ -35,7 +39,8 @@ class Puppet::Util::NetworkDevice::F5::Facts
       :partition,
       :platformId,
       :timeZone,
-      :version
+      :version,
+      :failoverState
     ].each do |fact|
       facts[fact] = result[fact.to_s]
     end


### PR DESCRIPTION
We currently run our LTMs in active-standby pairs. However, the management interface does not float to the active device during failover, so Puppet needs to be able to talk to each LTM separately.

This update adds a fact for failover state, so our manifest can determine whether the current device is active (and apply changes).

It also add the ability to choose the correct 'item' returned from '/mgmt/tm/cm/device' for the selfDevice.