### PR TITLE
Autoloading issues with providers

### DIFF
--- a/lib/puppet/provider/f5_command/rest.rb
+++ b/lib/puppet/provider/f5_command/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_command).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_configsync/rest.rb
+++ b/lib/puppet/provider/f5_configsync/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_configsync).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/provider/f5_profileclientssl/rest.rb
+++ b/lib/puppet/provider/f5_profileclientssl/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_profileclientssl).provide(:rest, parent: Puppet::Provider::F5) do


### PR DESCRIPTION
We had errors with the following resources due to how our environment finds modules:
    f5_configsync
    f5_command
    f5_profileclientssl

This change modifies require 'puppet/provider/f5' to require File.join(File.dirname(__FILE__), '../f5').

Error text:
"Could not autoload puppet/provider/f5_command/rest: no such file to load -- puppet/provider/f5 at"

Background information
   https://ask.puppet.com/question/19214/puppetlabs-f5-module-could-not-autoload-puppettypef5_node/

