### PR TITLE
Clientssl partitions

### DIFF
--- a/lib/puppet/provider/f5_profileclientssl/rest.rb
+++ b/lib/puppet/provider/f5_profileclientssl/rest.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/f5'
+require File.join(File.dirname(__FILE__), '../f5')
 require 'json'
 
 Puppet::Type.type(:f5_profileclientssl).provide(:rest, parent: Puppet::Provider::F5) do
@@ -25,6 +25,7 @@ Puppet::Type.type(:f5_profileclientssl).provide(:rest, parent: Puppet::Provider:
         authenticate:                profile['authenticate'],
         retain_certificate:          profile['retainCertificate'],
         authenticate_depth:          profile['authenticateDepth'],
+        partition:                   profile['partition'],
       )
     end
 

--- a/lib/puppet/provider/f5_profileclientssl/rest.rb
+++ b/lib/puppet/provider/f5_profileclientssl/rest.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../f5')
+require 'puppet/provider/f5'
 require 'json'
 
 Puppet::Type.type(:f5_profileclientssl).provide(:rest, parent: Puppet::Provider::F5) do

--- a/lib/puppet/type/f5_profileclientssl.rb
+++ b/lib/puppet/type/f5_profileclientssl.rb
@@ -68,4 +68,8 @@ Puppet::Type.newtype(:f5_profileclientssl) do
     desc "authenticate_depth."
   end
 
+  newproperty(:partition) do
+    desc "partition to install profile to."
+  end
+
 end


### PR DESCRIPTION
We create client ssl profiles in partitions in other than /Common. This change adds a parameter for partition that allows for the resource to specify what partition to create the profile in.