### PR TITLE
Add encrypted_password attribute to f5_user resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1477,7 +1477,7 @@ Valid options: a string.
 
 ##### description
 
-Sets the description of the user account.
+Sets the description of the user account, on versions of BIG-IP that support user descriptions.
 
 Valid options: a string.
 
@@ -1489,24 +1489,32 @@ Valid options: 'present' or 'absent'.
 
 ##### password
 
-Set the user password during creation or modification without prompting or confirmation.
+Manage the user's password, on older versions of BIG-IP, which use the "password" attribute.
+
+Valid options: a string
+
+##### encrypted_password
+
+Manage the user's encrypted password, on newer versions of BIG-IP, which use the "encryptedPassword" attribute.
+
+Valid options: a string
 
 #### Example
 
-##### Add a user
+##### Ensure a user is present, with the correct password hash
 ~~~puppet
-  f5_user { '/Common/joe':
-    name     => 'joe',
-    ensure   => 'present',
-    password => 'joe',
+  f5_user { '/Common/megan':
+    ensure             => 'present',
+    name               => 'megan',
+    encrypted_password => '$6$0v9y64sl$Yi3$To0many5ecrets$0ZBoqn0MzPp',
   }
 ~~~
 
-##### Delete a user
+##### Ensure a user is absent
 ~~~puppet
   f5_user { '/Common/joe':
-    name   => 'joe',
     ensure => 'absent',
+    name   => 'joe',
   }
 ~~~
 

--- a/lib/puppet/provider/f5_user/rest.rb
+++ b/lib/puppet/provider/f5_user/rest.rb
@@ -15,6 +15,7 @@ Puppet::Type.type(:f5_user).provide(:rest, parent: Puppet::Provider::F5) do
         name:                     user['fullPath'],
         description:              user['description'],
         password:                 user['password'],
+        encrypted_password:       user['encryptedPassword'],
       )
     end
 

--- a/lib/puppet/type/f5_user.rb
+++ b/lib/puppet/type/f5_user.rb
@@ -31,6 +31,11 @@ Puppet::Type.newtype(:f5_user) do
   newproperty(:description, :parent => Puppet::Property::F5Description)
 
   newproperty(:password) do
-    desc "password"
+    desc "password value, used by old BIG-IP versions"
   end
+
+  newproperty(:encrypted_password) do
+    desc "encryptedPassword value, used by newer BIG-IP versions"
+  end
+
 end


### PR DESCRIPTION
Newer versions of BIG-IP (thirteen, for instance) have an "encryptedPassword" attribute for users, rather than a "password" attribute.  This commit adds the code and associated readme text to support managing the encrypted password of a user.  It leaves the old behavior as well, for users still managing older f5 devices.