### PR TITLE
Fix f5_profileclientssl syntax error

### DIFF
--- a/lib/puppet/provider/f5_profileclientssl/rest.rb
+++ b/lib/puppet/provider/f5_profileclientssl/rest.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:f5_profileclientssl).provide(:rest, parent: Puppet::Provider:
         description:                 profile['description'],
         cert:                        profile['cert'],
         key:                         profile['key'],
-        chain:                       profile['chain']
+        chain:                       profile['chain'],
         proxy_ssl:                   profile['proxySsl'],
         proxy_ssl_passthrough:       profile['proxySslPassthrough'],
         ssl_forward_proxy:           profile['sslForwardProxy'],


### PR DESCRIPTION
When using the f5_profileclientssl resource under the current release, the following error is produced because of incorrect syntax:

`Could not autoload puppet/provider/f5_profileclientssl/rest: /opt/puppetlabs/puppet/cache/lib/puppet/provider/f5_profileclientssl/rest.rb:21: syntax error, unexpected tIDENTIFIER, expecting ')'`

This PR should fix the issue @ericzji @hunner 