### PR TITLE
puppet device --facts command returns same facts for both active and standby f5 devices

### DIFF
--- a/lib/puppet/util/network_device/f5/device.rb
+++ b/lib/puppet/util/network_device/f5/device.rb
@@ -19,11 +19,12 @@ class Puppet::Util::NetworkDevice::F5::Device
     end
     if @autoloader.load(*autoloader_params)
       @transport = Puppet::Util::NetworkDevice::Transport::F5.new(url,options[:debug])
+      @fqdn = url.split("@").last
     end
   end
 
   def facts
-    @facts ||= Puppet::Util::NetworkDevice::F5::Facts.new(@transport)
+    @facts ||= Puppet::Util::NetworkDevice::F5::Facts.new(@transport, @fqdn)
 
     return @facts.retrieve
   end

--- a/lib/puppet/util/network_device/f5/facts.rb
+++ b/lib/puppet/util/network_device/f5/facts.rb
@@ -2,8 +2,9 @@ class Puppet::Util::NetworkDevice::F5::Facts
 
   attr_reader :transport
 
-  def initialize(transport)
+  def initialize(transport, hostfqdn)
     @transport = transport
+    @hostfqdn = hostfqdn
   end
 
   def retrieve
@@ -17,7 +18,11 @@ class Puppet::Util::NetworkDevice::F5::Facts
     }
 
     if response = @transport.call('/mgmt/tm/cm/device') and items = response['items']
-      result = items.first
+       if  (items.first['name']) ==  @hostfqdn
+         result = items.first
+       else
+         result = items.last
+       end
     else
       Puppet.warning("Did not receive device details. iControl REST requires Administrator level access.")
       return facts


### PR DESCRIPTION
With out this fix, _puppet device --facts_ command returns same facts for both active and standby devices as it is always gathering the info from the first item returned by the /mgmt/tm/cm/device api.